### PR TITLE
Shorten Attributes Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ var h = require('virtual-hyperscript')
 
 var tree = h('div.foo#some-id', [
     h('span', 'some text'),
-    h('input', { type: 'text', value: 'foo' })
+    h('input', {
+      type: 'text',
+      value: 'foo',
+      attr: {
+        'data-input': "bar",
+        'custom-attribute': "test"
+      }
+    })
 ])
 ```
 
@@ -27,7 +34,7 @@ var tree = h('div.foo#some-id', [
 
 See [hyperscript](https://github.com/dominictarr/hyperscript) which has the
   same interface.
-  
+
 Except `virtual-hyperscript` returns a virtual DOM tree instead of a DOM
   element.
 
@@ -35,14 +42,14 @@ Except `virtual-hyperscript` returns a virtual DOM tree instead of a DOM
 
 `h()` takes a selector, an optional properties object and an
   optional array of children or a child that is a string.
-  
+
 If you pass it a selector like `span.foo.bar#some-id` it will
   parse the selector and change the `id` and `className`
   properties of the `properties` object.
-  
+
 If you pass it an array of `children` it will have child
   nodes, normally ou want to create children with `h()`.
-  
+
 If you pass it a string it will create an array containing
   a single child node that is a text element.
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,39 @@ function h(tagName, properties, children) {
         props = {}
     }
 
+    /**
+      Shorten Attributes Writing
+    */
+    // If Has Attr
+    if(properties.attr) {
+      var attrs = properties.attr;
+      var attrKeys = Object.keys(properties.attr);
+
+      // If has both attr and attributes
+      if(properties.attributes){
+
+        // Simple Assign
+        var attributeKeys = Object.keys(properties.attributes);
+        for (var i = 0; i < attrKeys.length; i++) {
+          var attrName = attrKeys[i]
+
+          // Checking...
+          for (var j = 0; j < attributeKeys.length; j++) {
+            var attributeName = attributeKeys[j]
+            var notSame = attributeName !== attrName
+            if(notSame) properties.attributes[attrName] = properties.attr[attrName];
+          }
+
+        }
+      }
+
+      // Else, Only has attr
+      else properties.attributes = properties.attr
+
+      // Remove Attr
+      delete properties.attr
+    }
+
     props = props || properties || {}
     tag = parseTag(tagName, props)
 


### PR DESCRIPTION
Just want to shortenig attributes writing style. :grin: 
The default "attributes" writing style is still available~